### PR TITLE
[Fix] #7 - User DTO 변경 및 Response 수정

### DIFF
--- a/sfaas/src/main/java/org/hae/sfaas/domain/user/controller/UserController.java
+++ b/sfaas/src/main/java/org/hae/sfaas/domain/user/controller/UserController.java
@@ -27,7 +27,7 @@ public class UserController {
 
     @GetMapping("/users")
     public ResponseEntity<SFaaSResponse<?>> getUserInfos(@RequestParam("userId") Long userId) {
-        List<UserInfoResponse> response = userService.getUserInfos(userId);
+        List<UserDetailInfoResponse> response = userService.getUserInfos(userId);
         return ResponseEntity.status(HttpStatus.OK).body(SFaaSResponse.success(SuccessType.GET_USERINFOS_SUCCESS, response));
     }
 

--- a/sfaas/src/main/java/org/hae/sfaas/domain/user/dto/response/UserDetailInfoResponse.java
+++ b/sfaas/src/main/java/org/hae/sfaas/domain/user/dto/response/UserDetailInfoResponse.java
@@ -6,22 +6,28 @@ import org.hae.sfaas.domain.user.model.UserRole;
 import java.time.LocalDateTime;
 
 public record UserDetailInfoResponse(
+        Long userId,
         Long factoryId,
         String userEmail,
         String userName,
         Long userMgr,
         UserRole userRole,
+        String department,
+        String position,
         LocalDateTime lastLoginAt,
         String factoryCode,
         String factoryLocation
 ) {
     public static UserDetailInfoResponse of(DetailUser detailUser) {
         return new UserDetailInfoResponse(
+                detailUser.getUserId(),
                 detailUser.getFactoryId(),
                 detailUser.getUserEmail(),
                 detailUser.getUserName(),
                 detailUser.getUserMgr(),
                 detailUser.getUserRole(),
+                detailUser.getDepartment(),
+                detailUser.getPosition(),
                 detailUser.getLastLoginAt(),
                 detailUser.getFactoryCode(),
                 detailUser.getFactoryLocation()

--- a/sfaas/src/main/java/org/hae/sfaas/domain/user/dto/response/UserInfoResponse.java
+++ b/sfaas/src/main/java/org/hae/sfaas/domain/user/dto/response/UserInfoResponse.java
@@ -8,20 +8,26 @@ import org.hae.sfaas.domain.user.model.UserRole;
 import java.time.LocalDateTime;
 
 public record UserInfoResponse(
+        Long userId,
         Long factoryId,
         String userEmail,
         String userName,
         Long userMgr,
         UserRole userRole,
+        String department,
+        String position,
         LocalDateTime lastLoginAt
 ) {
     public static UserInfoResponse of(User user) {
         return new UserInfoResponse(
+                user.getUserId(),
                 user.getFactoryId(),
                 user.getUserEmail(),
                 user.getUserName(),
                 user.getUserMgr(),
                 user.getUserRole(),
+                user.getDepartment(),
+                user.getPosition(),
                 user.getLastLoginAt()
         );
     }

--- a/sfaas/src/main/java/org/hae/sfaas/domain/user/mapper/UserMapper.java
+++ b/sfaas/src/main/java/org/hae/sfaas/domain/user/mapper/UserMapper.java
@@ -13,8 +13,8 @@ import java.util.List;
 public interface UserMapper {
     User loginUser(UserLoginRequest request);
     User findById(Long userId);
-    List<User> findAll();
-    List<User> findByFactoryId(Long factoryId);
+    List<DetailUser> findAll();
+    List<DetailUser> findByFactoryId(Long factoryId);
     DetailUser getMyInfo(Long userId);
     void updateUserRoleById(Long userId, UserRole role);
 

--- a/sfaas/src/main/java/org/hae/sfaas/domain/user/model/DetailUser.java
+++ b/sfaas/src/main/java/org/hae/sfaas/domain/user/model/DetailUser.java
@@ -12,6 +12,8 @@ public class DetailUser {
     private String userPwd;
     private String userName;
     private Long userMgr;
+    private String department;
+    private String position;
     private UserRole userRole;  // "ADMIN", "MANAGER", "USER"
     private LocalDateTime lastLoginAt;
     private String factoryCode;

--- a/sfaas/src/main/java/org/hae/sfaas/domain/user/model/User.java
+++ b/sfaas/src/main/java/org/hae/sfaas/domain/user/model/User.java
@@ -13,5 +13,7 @@ public class User {
     private String userName;
     private Long userMgr;
     private UserRole userRole;  // "ADMIN", "MANAGER", "USER"
+    private String department;
+    private String position;
     private LocalDateTime lastLoginAt;
 }

--- a/sfaas/src/main/java/org/hae/sfaas/domain/user/service/UserService.java
+++ b/sfaas/src/main/java/org/hae/sfaas/domain/user/service/UserService.java
@@ -33,13 +33,13 @@ public class UserService {
         return UserInfoResponse.of(user);
     }
 
-    public List<UserInfoResponse> getUserInfos(Long userId) {
+    public List<UserDetailInfoResponse> getUserInfos(Long userId) {
         User user = userMapper.findById(userId);
         if(isInvalidUser(user)) {
             throw new SFaaSException(ErrorType.NOT_FOUND_USER);
         }
 
-        List<User> users = null;
+        List<DetailUser> users = null;
         if (user.getUserRole().equals(UserRole.ADMIN)) {
             users = userMapper.findAll();
         } else if (user.getUserRole().equals(UserRole.MANAGER)) {
@@ -48,7 +48,7 @@ public class UserService {
             throw new SFaaSException(ErrorType.FORBIDDEN_USER);
         }
 
-        return users.stream().map(UserInfoResponse::of).toList();
+        return users.stream().map(UserDetailInfoResponse::of).toList();
     }
 
     @Transactional

--- a/sfaas/src/main/resources/mappers/postgre/main/user/UserMapper.xml
+++ b/sfaas/src/main/resources/mappers/postgre/main/user/UserMapper.xml
@@ -22,15 +22,17 @@
         WHERE user_id = #{userId}
     </select>
 
-    <select id="findAll" resultType="User">
-        SELECT *
-        FROM ${sfaas.db.schema}.user
+    <select id="findAll" resultType="DetailUser">
+        SELECT u.*, f.factory_code, f.factory_location
+        FROM ${sfaas.db.schema}.user u
+        JOIN ${sfaas.db.schema}.factory f ON u.factory_id = f.factory_id
     </select>
 
-    <select id="findByFactoryId" parameterType="Long" resultType="User">
-        SELECT *
-        FROM ${sfaas.db.schema}.user
-        WHERE factory_id = #{factoryId}
+    <select id="findByFactoryId" parameterType="Long" resultType="DetailUser">
+        SELECT u.*, f.factory_code, f.factory_location
+        FROM ${sfaas.db.schema}.user u
+        JOIN ${sfaas.db.schema}.factory f ON u.factory_id = f.factory_id
+        WHERE u.factory_id = #{factoryId}
     </select>
 
     <select id="getMyInfo" parameterType="Long" resultType="DetailUser">


### PR DESCRIPTION
## 🚀PullRequest🚀

#### ✅ PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- 기존 Response에 user_id가 없어서 추가하였습니다.
- UserTable 부서, 직급 추가하였습니다.
- 사용자 리스트 조회에서도 UserDetailInfoResponse를 사용하도록 변경하였습니다. 이로 인해 UserMapper의 findAll(), findFactoryById() SQL문이 변경되었습니다.
-  예시는 아래와 같습니다. 다른 API 테스트 결과 이미지는 노션에 업로드 해두었습니다 !
<img width="540" alt="스크린샷 2024-12-13 오후 10 29 33" src="https://github.com/user-attachments/assets/7531a52f-1ca1-4585-9131-d7fa8f28d9e7" />


### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->


### 📟 관련 이슈
- Resolved: #7 
